### PR TITLE
Bug fix, ui rearrangement

### DIFF
--- a/Bottle-Racket/testing/ps2a/test-results-email.txt
+++ b/Bottle-Racket/testing/ps2a/test-results-email.txt
@@ -1,0 +1,6 @@
+>>> Results for test area file 'ps2a_area.rkt'
+
+-> Total: 15
+-> Passed: 15 (100%)
+-> Failed: 0 (0%)
+

--- a/Bottle-Racket/testing/ps2a/test-results.txt
+++ b/Bottle-Racket/testing/ps2a/test-results.txt
@@ -1,0 +1,4 @@
+Starting Test Suite 'ps2a'
+Finished Test Suite 'ps2a'
+15 success(es) 0 failure(s) 0 error(s) 15 test(s) run
+'(0)

--- a/Test-Automation/autotest.rkt
+++ b/Test-Automation/autotest.rkt
@@ -243,7 +243,7 @@
       (when thu? (set! due-week-days (append due-week-days (list 4))))
       (when fri? (set! due-week-days (append due-week-days (list 5))))
       (when sat? (set! due-week-days (append due-week-days (list 6)))))    
-    (define (find-next-due-date)
+    (define (find-next-due-date)  ; for recurring test
       (when DEBUG
         (printf "Starting (find-next-due-date)~n"))
       (week-days-to-list)
@@ -253,12 +253,14 @@
         (printf "due-week-days = ~a~n" due-week-days))
       (cond ((null? due-week-days) #f)
             ((and (member current-week-day due-week-days)
-                  (<= (+ (* (date-hour (current-date)) 60) (date-minute (current-date)))  ; is due today
-                      (+ (* hour-in-24 60) minute)))
+                  (<= (+ (* (date-hour (current-date)) 3600) 
+                         (* 60 (date-minute (current-date))) 
+                         (date-second (current-date)))  
+                      (+ (* hour-in-24 3600) (* minute 60))))  ; is due today
              (date-day (current-date)))
-            ((and (member current-week-day due-week-days)  ; was due today, now due a week later
+            ((and (member current-week-day due-week-days)  
                   (equal? (length due-week-days) 1))
-             (+ 7 (date-day (current-date))))
+             (+ 7 (date-day (current-date))))  ; was due today, now due a week later
             ((eq? #f (findf (lambda (day) (> day current-week-day)) due-week-days))
              (+ (date-day (current-date))
                 (- 7 (- current-week-day (argmin identity due-week-days)))))  ; wrapped around to next week
@@ -479,35 +481,6 @@
 (define (autotest-set-reserved-field-3 at value) (at 'set-reserved-field-3 value))
 (define (autotest-set-reserved-field-4 at value) (at 'set-reserved-field-4 value))
 (define (autotest-set-reserved-field-5 at value) (at 'set-reserved-field-5 value))
-
-(define (copy-autotest! from-at to-at)
-  (autotest-set-name to-at (autotest-name from-at))
-  (autotest-set-active? to-at (autotest-active? from-at))
-  (autotest-set-files to-at (autotest-files from-at))
-  (autotest-set-type to-at (autotest-type from-at))
-  (autotest-set-year to-at (autotest-year from-at))
-  (autotest-set-month to-at (autotest-month from-at))
-  (autotest-set-date to-at (autotest-date from-at))
-  (autotest-set-daily? to-at (autotest-daily? from-at))
-  (autotest-set-mon? to-at (autotest-mon? from-at))
-  (autotest-set-tue? to-at (autotest-tue? from-at))
-  (autotest-set-wed? to-at (autotest-wed? from-at))
-  (autotest-set-thu? to-at (autotest-thu? from-at))
-  (autotest-set-fri? to-at (autotest-fri? from-at))
-  (autotest-set-sat? to-at (autotest-sat? from-at))
-  (autotest-set-sun? to-at (autotest-sun? from-at))
-  (autotest-set-hour to-at (autotest-hour from-at))
-  (autotest-set-minute to-at (autotest-minute from-at))
-  (autotest-set-ampm to-at (autotest-ampm from-at))
-  (autotest-set-notify? to-at (autotest-notify? from-at))
-  (autotest-set-email-db to-at (autotest-email-db from-at))
-  (autotest-set-last-run to-at (autotest-last-run from-at))
-  (autotest-set-reserved-field-1 to-at (autotest-reserved-field-1 from-at))
-  (autotest-set-reserved-field-2 to-at (autotest-reserved-field-2 from-at))
-  (autotest-set-reserved-field-3 to-at (autotest-reserved-field-3 from-at))
-  (autotest-set-reserved-field-4 to-at (autotest-reserved-field-4 from-at))
-  (autotest-set-reserved-field-5 to-at (autotest-reserved-field-5 from-at))
-  (write-autotest to-at))
 
 (define (create-duplicate-autotest at)
   (let loop ((i 2))

--- a/Test-Automation/scheduler_runner.rkt
+++ b/Test-Automation/scheduler_runner.rkt
@@ -1,5 +1,0 @@
-#lang racket
-
-(require "scheduler_ui.rkt")
-
-(launch-scheduler)

--- a/Test-Automation/scheduler_ui.rkt
+++ b/Test-Automation/scheduler_ui.rkt
@@ -7,15 +7,16 @@
  | tests.
  |#
 
-#lang racket/gui
+#lang racket
 
 (require racket/date
          racket/flonum
+         racket/gui/base
          "autotest.rkt"
          "bg-process.rkt"
          "calendar.rkt"
          "input-validation.rkt"
-         "scheduler.rkt"         
+         "scheduler.rkt"
          "../QA-Email/email-db.rkt"
          "../QA-Email/email-db-ui.rkt")
 
@@ -26,13 +27,14 @@
 (define NO-INACTIVE-AUTOTEST-MESSAGE "No inactive autotest")
 (define NO-AUTOTEST-SELECTED-MESSAGE "** No autotest selected **  ")
 (define NO-MAILING-LIST-MESSAGE "No mailing list selected  ")
-(define VALID-BG-COLOR "White")
-(define INVALID-BG-COLOR "Red")
-(define warning-icon (make-object bitmap% "images/warning-1.png" 'png))
+(define NO-AUTOTEST-SCHEDULED-MESSAGE "No autotest scheduled  ")
+(define VALID-FIELD-COLOR (make-object color% "White"))
+(define INVALID-FIELD-COLOR (make-object color% "Red"))
+(define WARNING-ICON (make-object bitmap% "images/warning-1.png" 'png))
 
 (define selected-email-db #f)
-(define APPROXIMATE-SIZE-X 700)
-(define APPROXIMATE-SIZE-Y 600)
+(define APPROXIMATE-SIZE-X 750)
+(define APPROXIMATE-SIZE-Y 650)
 
 (define-values (size-x size-y) (get-display-size))
 (define x-pos (fl->exact-integer (* (- size-x APPROXIMATE-SIZE-X) 0.5)))
@@ -45,16 +47,16 @@
 ;;       (kill-thread timer)
 ;;       (kill-thread runner))))
 
-(define manage-scheduler-frame  
+(define main-frame
   (new frame%
-       (label "Manage Automated Tests")
+       (label "Test Scheduler")
        (x x-pos)
        (y y-pos)
        (spacing 2)))
 
 (define main-h-panel
   (new horizontal-panel%
-       (parent manage-scheduler-frame)
+       (parent main-frame)
        (spacing 10)
        (border 8)
        (alignment '(left top))))
@@ -68,9 +70,8 @@
 
 (define right-v-panel
   (new vertical-panel%
-       (parent main-h-panel)  
+       (parent main-h-panel)
        (spacing 4)
-       (min-width 400)
        (alignment '(left top))))
 
 ;; List box for active tests (left pane).
@@ -81,26 +82,24 @@
        (choices '())
        (horiz-margin 0)
        (vert-margin 2)
-       (min-width 220)
        (min-height 180)
        (style '(single vertical-label))
        (callback
         (lambda (list click-type)
-          (define selection-in-inactive-tests-list-box (send inactive-tests-list-box get-selection))
-          (when (not (equal? #f selection-in-inactive-tests-list-box))
-            (send inactive-tests-list-box select selection-in-inactive-tests-list-box #f))
-          (setup-ui)))))
+          (let ((selection-in-inactive-tests-list-box (send inactive-tests-list-box get-selection)))
+            (when (not (equal? #f selection-in-inactive-tests-list-box))
+              (send inactive-tests-list-box select selection-in-inactive-tests-list-box #f))
+            (setup-ui))))))
 
 ;; Fills the active autotest list box (left pane).
 (define (populate-active-tests-list-box)
-  (define active-test-list (filter autotest-active? autotest-list))  
-  (define (add-to-list-box test)
-    (define name (autotest-name test))
-    (send active-tests-list-box append name test))  
-  (send active-tests-list-box clear)
-  (cond ((equal? (length active-test-list) 0)
-         (send active-tests-list-box append NO-ACTIVE-AUTOTEST-MESSAGE))
-        (else (map add-to-list-box active-test-list))))
+  (let ((active-test-list (filter autotest-active? autotest-list))
+        (add-to-list-box
+         (lambda (test) (send active-tests-list-box append (autotest-name test) test))))
+    (send active-tests-list-box clear)
+    (cond ((null? active-test-list)
+           (send active-tests-list-box append NO-ACTIVE-AUTOTEST-MESSAGE))
+          (else (for-each add-to-list-box active-test-list)))))
 
 ;; List box for inactive tests (left pane).
 (define inactive-tests-list-box
@@ -110,33 +109,32 @@
        (choices '())
        (horiz-margin 0)
        (vert-margin 0)
-       (min-width (send active-tests-list-box get-width))
        (min-height 200)
        (style '(single vertical-label))
        (callback
         (lambda (list click-type)
-          (define selection-in-active-tests-list-box (send active-tests-list-box get-selection))
-          (when (not (equal? #f selection-in-active-tests-list-box))
-            (send active-tests-list-box select selection-in-active-tests-list-box #f))
-          (setup-ui)))))
+          (let ((selection-in-active-tests-list-box (send active-tests-list-box get-selection)))
+            (when (not (equal? #f selection-in-active-tests-list-box))
+              (send active-tests-list-box select selection-in-active-tests-list-box #f))
+            (setup-ui))))))
 
 ;; Fills the inactive autotest list box (left pane)
 (define (populate-inactive-tests-list-box)
-  (define inactive-test-list (filter (negate autotest-active?) autotest-list))
-  (define (add-to-list-box test)
-    (define name (autotest-name test))
-    (send inactive-tests-list-box append name test))
-  (send inactive-tests-list-box clear)
-  (cond ((equal? (length inactive-test-list) 0)
-         (send inactive-tests-list-box append NO-INACTIVE-AUTOTEST-MESSAGE))
-        (else (map add-to-list-box inactive-test-list))))
+  (let ((inactive-test-list (filter (negate autotest-active?) autotest-list))
+        (add-to-list-box
+         (lambda (test) (send inactive-tests-list-box append (autotest-name test) test))))
+    (send inactive-tests-list-box clear)
+    (cond ((null? inactive-test-list)
+           (send inactive-tests-list-box append NO-INACTIVE-AUTOTEST-MESSAGE))
+          (else (for-each add-to-list-box inactive-test-list)))))
 
 (define last-run-label
   (new message%
        (parent left-v-panel)
        (label "Last Run:  ")
+       (min-width 220)
        (vert-margin 0)
-       (auto-resize #t)))
+       (auto-resize #f)))
 
 (define last-run-text
   (new message%
@@ -150,7 +148,7 @@
        (parent left-v-panel)
        (label "Next Due:  ")
        (vert-margin 0)
-       (auto-resize #t)))
+       (auto-resize #f)))
 
 (define next-due-text
   (new message%
@@ -159,11 +157,27 @@
        (vert-margin 0)
        (auto-resize #t)))
 
+(define (refresh-run-info)
+  (let ((active-selection (send active-tests-list-box get-selection))
+        (inactive-selection (send inactive-tests-list-box get-selection)))
+    (define at (cond (active-selection (send active-tests-list-box get-data active-selection))
+                     (inactive-selection (send inactive-tests-list-box get-data inactive-selection))
+                     (else #f)))
+    (when at
+      (send last-run-text set-label (autotest-last-run-string at))
+      (send next-due-text set-label (autotest-next-due-string at)))))
+
+(thread (lambda ()
+          (let loop ()
+            (refresh-run-info)
+            (sleep 1.0)
+            (loop))))
+
 (define autotest-actions-choice
   (new choice%
        (parent left-v-panel)
        (label #f)
-       (min-width (send active-tests-list-box min-width))
+       (min-width 220)
        (horiz-margin 0)
        (vert-margin 3)
        (choices (list "Autotest Actions"
@@ -173,60 +187,47 @@
                       "Delete this test"))
        (callback
         (lambda (ch e)
-          (let ((selected-index (send autotest-actions-choice get-selection)))
-            (cond ((equal? selected-index 0)
-                   (void))
-                  ((equal? selected-index 1)  ; activate
-                   (let ((inactive-selection (send inactive-tests-list-box get-selection)))
-                     (when (and (not (equal? #f inactive-selection))
-                                (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE 
-                                             (send inactive-tests-list-box get-string-selection))))
-                       (let ((at (send inactive-tests-list-box get-data inactive-selection)))
-                         (autotest-set-active? at #t)
-                         (write-autotest-list)
-                         (write-autotest at)))))
+          (let ((selected-index (send autotest-actions-choice get-selection))
+                (active-selection (send active-tests-list-box get-selection))
+                (active-string (send active-tests-list-box get-string-selection))
+                (inactive-selection (send inactive-tests-list-box get-selection))
+                (inactive-string (send inactive-tests-list-box get-string-selection)))
+            (cond ((equal? selected-index 1)  ; activate
+                   (when (and (not (equal? #f inactive-selection))
+                              (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE inactive-string)))
+                     (let ((at (send inactive-tests-list-box get-data inactive-selection)))
+                       (autotest-set-active? at #t)
+                       (write-autotest-list)
+                       (write-autotest at))))
                   ((equal? selected-index 2)  ; deactivate
-                   (let ((active-selection (send active-tests-list-box get-selection)))
-                     (when (and (not (equal? #f active-selection))
-                                (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE 
-                                             (send active-tests-list-box get-string-selection))))
-                       (let ((at (send active-tests-list-box get-data active-selection)))
-                         (autotest-set-active? at #f)
-                         (write-autotest-list)
-                         (write-autotest at)))))
+                   (when (and (not (equal? #f active-selection))
+                              (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE active-string)))
+                     (let ((at (send active-tests-list-box get-data active-selection)))
+                       (autotest-set-active? at #f)
+                       (write-autotest-list)
+                       (write-autotest at))))
                   ((equal? selected-index 3)  ; duplicate
-                   (let ((active-selection (send active-tests-list-box get-selection))
-                         (inactive-selection (send inactive-tests-list-box get-selection)))
-                     (cond ((and (not (equal? #f active-selection))
-                                 (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE 
-                                              (send active-tests-list-box get-string-selection))))
-                            (let ((at (send active-tests-list-box get-data active-selection)))
-                              (create-duplicate-autotest at)
-                              (setup-ui)))
-                           ((and (not (equal? #f inactive-selection))
-                                 (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE
-                                              (send inactive-tests-list-box get-string-selection))))
-                            (let ((at (send inactive-tests-list-box get-data inactive-selection)))
-                              (create-duplicate-autotest at)
-                              (setup-ui)))
-                           (else (void)))))
+                   (cond ((and (not (equal? #f active-selection))
+                               (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE active-string)))
+                          (create-duplicate-autotest 
+                           (send active-tests-list-box get-data active-selection)))
+                         ((and (not (equal? #f inactive-selection))
+                               (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE inactive-string)))
+                          (create-duplicate-autotest 
+                           (send inactive-tests-list-box get-data inactive-selection)))
+                         (else (void))))
                   ((equal? selected-index 4)  ; delete
-                   (let ((active-selection (send active-tests-list-box get-selection))
-                         (inactive-selection (send inactive-tests-list-box get-selection)))
-                     (cond ((and (not (equal? #f active-selection))
-                                 (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE 
-                                              (send active-tests-list-box get-string-selection))))
-                            (let ((at (send active-tests-list-box get-data active-selection)))
-                              (remove-from-autotest-list (autotest-id at))
-                              (setup-ui)))
-                           ((and (not (equal? #f inactive-selection))
-                                 (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE
-                                              (send inactive-tests-list-box get-string-selection))))
-                            (let ((at (send inactive-tests-list-box get-data inactive-selection)))
-                              (remove-from-autotest-list (autotest-id at))))
-                           (else (void)))))
+                   (cond ((and (not (equal? #f active-selection))
+                               (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE active-string)))
+                          (remove-from-autotest-list 
+                           (autotest-id (send active-tests-list-box get-data active-selection))))
+                         ((and (not (equal? #f inactive-selection))
+                               (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE inactive-string)))
+                          (remove-from-autotest-list 
+                           (autotest-id (send inactive-tests-list-box get-data inactive-selection))))
+                         (else (void))))
                   (else
-                   (printf "Autotest Action: Unknown Action~n")))
+                   (void)))
             (populate-active-tests-list-box)
             (populate-inactive-tests-list-box)
             (send autotest-actions-choice set-selection 0)
@@ -277,7 +278,7 @@
         (lambda (b e)
           (config-ui-create-mode)))))
 
-;; files list box
+;; files list-box
 (define test-resource-panel
   (new group-box-panel%
        (parent right-v-panel)
@@ -286,7 +287,7 @@
        (spacing 5)
        (alignment '(left top))))
 
-(define files-list-and-buttons-pane 
+(define files-list-and-buttons-pane
   (new horizontal-pane%
        (parent test-resource-panel)
        (alignment '(left top))))
@@ -310,13 +311,11 @@
   (new button%
        (parent right-buttons-pane)
        (label "Add...")
-       (callback 
+       (callback
         (lambda (b e)
-          (let ((filepaths (get-file-list "Select test files" manage-scheduler-frame)))
-            (when (not (eq? filepaths #f))                   
-              (define (add-to-file-list-box path)
-                (send files-list-box append (path->string path)))
-              (map add-to-file-list-box filepaths))
+          (let ((filepaths (get-file-list "Select test files" main-frame)))
+            (when (not (eq? filepaths #f))
+              (for-each (lambda (path) (send files-list-box append (path->string path))) filepaths))
             (toggle-files-warning-icon))))))
 
 ;; Button to remove files
@@ -326,10 +325,9 @@
        (label "Remove")
        (callback
         (lambda (b e)
-          (let ((selected-indexes (sort (send files-list-box get-selections) >))
-                (delete-n (lambda (n) (send files-list-box delete n))))
+          (let ((selected-indexes (sort (send files-list-box get-selections) >)))
             (when (not (null? selected-indexes))
-              (for-each delete-n selected-indexes))
+              (for-each (lambda (n) (send files-list-box delete n)) selected-indexes))
             (toggle-files-warning-icon))))))
 
 (define files-warning-pane
@@ -337,11 +335,11 @@
        (parent right-buttons-pane)
        (alignment '(left bottom))))
 
-;; warning sign when no file is specified 
+;; warning sign when no file is specified
 (define files-list-box-warning-label
   (new message%
        (parent files-warning-pane)
-       (label warning-icon)))
+       (label WARNING-ICON)))
 
 ;; area below files list box - configures time schedule
 (define schedule-panel
@@ -396,25 +394,29 @@
 
 ;; Some UIs need to be disabled depending on whether one-time or periodic
 ;; radio button is selected.
-(define (toggle-onetime-periodic)
-  (define selected-index (send one-time-periodic-radio-box get-selection)) 
-  (if (eq? selected-index 0)  ; one-time
-      (begin (disable-all-children days-of-week-pane)
-             (enable-all-children date-picker-pane))
-      (begin (send date-text-field set-field-background (make-object color% VALID-BG-COLOR))
-             (disable-all-children date-picker-pane)
-             (enable-all-children days-of-week-pane))))
+(define (toggle-onetime-periodic-pane)
+  (let ((selected-index (send one-time-periodic-radio-box get-selection)))
+    (if (eq? selected-index 0)  ; one-time
+        (begin (set-one-time-fields-background)
+               (disable-all-children days-of-week-pane)
+               (enable-all-children date-picker-pane))
+        (begin (set-one-time-fields-background #f)  ; periodic
+               (when (send check-daily get-value)
+                 (check-all-days))
+               (disable-all-children date-picker-pane)
+               (enable-all-children days-of-week-pane)
+               (toggle-periodic-warning-icon)))))
 
 (define one-time-periodic-radio-box
   (new radio-box%
        (parent schedule-panel)
        (label #f)
        (style '(horizontal))
-       (choices '("One-Time" "Periodic"))
+       (choices '("One-Time" "Repeat"))
        (selection 0)
        (callback
         (lambda (r e)
-          (toggle-onetime-periodic)))))
+          (toggle-onetime-periodic-pane)))))
 
 (define one-time-group-box
   (new group-box-panel%
@@ -439,9 +441,7 @@
        (init-value (number->string (current-year)))
        (callback
         (lambda (c e)
-          (set-date-text-field-background)
-          (set-month-combo-field-background)
-          (set-year-combo-field-background)))))
+          (set-one-time-fields-background)))))
 
 (define month-combo-field
   (new combo-field%
@@ -453,9 +453,7 @@
        (init-value (number->string (current-month)))
        (callback
         (lambda (c e)
-          (set-date-text-field-background)
-          (set-month-combo-field-background)
-          (set-year-combo-field-background)))))
+          (set-one-time-fields-background)))))
 
 (define date-text-field
   (new text-field%
@@ -466,14 +464,12 @@
        (init-value (number->string (current-day)))
        (callback
         (lambda (t e)
-          (set-date-text-field-background)
-          (set-month-combo-field-background)
-          (set-year-combo-field-background)))))
+          (set-one-time-fields-background)))))
 
 (define periodic-group-box
   (new group-box-panel%
        (parent schedule-panel)
-       (label "Periodic")
+       (label "Repeat")
        (border 5)))
 
 (define days-of-week-pane
@@ -501,6 +497,7 @@
   (send check-friday set-value #t)
   (send check-saturday set-value #t)
   (send check-sunday set-value #t))
+
 (define (uncheck-all-days)
   (send check-monday set-value #f)
   (send check-tuesday set-value #f)
@@ -521,10 +518,12 @@
               (check-all-days)
               (uncheck-all-days))
           (toggle-periodic-warning-icon)))))
+
 (new message%
      (parent days-of-week-pane)
      (label "")
-     (min-width 10)) 
+     (min-width 10))
+
 (define check-monday
   (new check-box%
        (parent days-of-week-pane)
@@ -589,17 +588,19 @@
           (toggle-check-daily c)
           (toggle-periodic-warning-icon)))))
 
+;; Turns on when periodic test is selected but no days are checked.
 (define periodic-warning-label
   (new message%
        (parent days-of-week-pane)
-       (label warning-icon)))
+       (label WARNING-ICON)))
+
 ;; UI for configuring email notification
 (define email-panel
   (new group-box-panel%
        (parent right-v-panel)
        (label "Notify results via email")
        (border 2)
-       (min-height 60)  ; see if this can go later
+       (min-height 60)
        (alignment '(left top))))
 
 (define email-v-pane
@@ -608,17 +609,12 @@
        (spacing 2)
        (alignment '(left center))))
 
-;; TODO: Check if mailing list is selected when Notify? is checked.
 (define check-notify
   (new check-box%
        (parent email-v-pane)
        (label "Notify?")
        (horiz-margin 10)
-       (value #f)
-       (callback 
-        (lambda (c e)
-          (define checked? (send check-notify get-value))
-          (void)))))
+       (value #f)))
 
 (define email-h-pane
   (new horizontal-pane%
@@ -652,7 +648,7 @@
   (new button%
        (parent email-db-button-h-pane)
        (label "Select mailing list...")
-       (callback 
+       (callback
         (lambda (b e)
           (let ((email-db (open-manage-mailing-list-dialog 'return-db)))
             (when (not (equal? #f email-db))
@@ -666,17 +662,49 @@
        (vert-margin 3)
        (alignment '(center top))))
 
+(define saved-changes-label
+  (new message%
+       (parent activate-buttons-pane)
+       (label "Saved changes")
+       (min-height 30)))
+
 (define (show-saved-message)
   (thread
    (lambda ()
      (send saved-changes-label show #t)
      (sleep 1.0)
      (send saved-changes-label show #f))))
-      
+
+(define (save-changes at)
+  (let ((temp-at (make-autotest-from-ui (autotest-active? at))))
+    (autotest-set-name at (autotest-name temp-at))
+    (autotest-set-active? at (autotest-active? temp-at))
+    (autotest-set-files at (autotest-files temp-at))
+    (autotest-set-type at (autotest-type temp-at))
+    (autotest-set-year at (autotest-year temp-at))
+    (autotest-set-month at (autotest-month temp-at))
+    (autotest-set-date at (autotest-date temp-at))
+    (autotest-set-daily? at (autotest-daily? temp-at))
+    (autotest-set-mon? at (autotest-mon? temp-at))
+    (autotest-set-tue? at (autotest-tue? temp-at))
+    (autotest-set-wed? at (autotest-wed? temp-at))
+    (autotest-set-thu? at (autotest-thu? temp-at))
+    (autotest-set-fri? at (autotest-fri? temp-at))
+    (autotest-set-sat? at (autotest-sat? temp-at))
+    (autotest-set-sun? at (autotest-sun? temp-at))
+    (autotest-set-hour at (autotest-hour temp-at))
+    (autotest-set-minute at (autotest-minute temp-at))
+    (autotest-set-ampm at (autotest-ampm temp-at))
+    (autotest-set-notify? at (autotest-notify? temp-at))
+    (autotest-set-email-db at (autotest-email-db temp-at))
+    (write-autotest at)))
+
+;; Saves configurations in the UI to the currently selected autotest item.
 (define save-changes-button
   (new button%
        (parent activate-buttons-pane)
        (label "Save Changes")
+       (min-height 30)
        (callback
         (lambda (b e)
           (let ((active-selection (send active-tests-list-box get-selection))
@@ -684,32 +712,29 @@
             (cond ((not (entries-are-valid?))
                    (toggle-warning-icons))
                   ((and (not (equal? #f active-selection))
-                        (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE 
+                        (not (equal? NO-ACTIVE-AUTOTEST-MESSAGE
                                      (send active-tests-list-box get-string-selection))))
                    (let ((at (send active-tests-list-box get-data active-selection)))
-                     (copy-autotest! (make-autotest-from-ui (autotest-active? at)) at)
+                     (save-changes at)
                      (show-saved-message)
+                     
                      (toggle-warning-icons #f)))
                   ((and (not (equal? #f inactive-selection))
                         (not (equal? NO-INACTIVE-AUTOTEST-MESSAGE
                                      (send inactive-tests-list-box get-string-selection))))
                    (let ((at (send inactive-tests-list-box get-data inactive-selection)))
-                     (copy-autotest! (make-autotest-from-ui (autotest-active? at)) at)
+                     (save-changes at)
                      (show-saved-message)
                      (toggle-warning-icons #f)))
                   (else (void))))))))
 
-(define saved-changes-label
-  (new message%
-       (parent activate-buttons-pane)
-       (label "Saved changes")))
-
-;; 'Create and Activate' Button 
+;; 'Create and Activate' Button
 ;; - Creates a new test and activates it at the same time
 (define create-active-button
   (new button%
        (parent activate-buttons-pane)
        (label "Create and Activate")
+       (min-height 30)
        (callback
         (lambda (b e)
           (if (entries-are-valid?)
@@ -725,6 +750,7 @@
   (new button%
        (parent activate-buttons-pane)
        (label "Create as Inactive")
+       (min-height 30)
        (callback
         (lambda (b e)
           (if (entries-are-valid?)
@@ -739,20 +765,20 @@
   (new button%
        (parent activate-buttons-pane)
        (label "Cancel")
+       (min-height 30)
        (callback
-        (lambda (b e) 
+        (lambda (b e)
           (toggle-warning-icons #f)
           (setup-ui)))))
 
 ;; Creates a new autotest.
 (define (make-autotest-from-ui (activate? #t))
   (when (entries-are-valid?)
-    (let ((id (generate-autotest-id))
-          (num-files (send files-list-box get-number))
+    (let ((num-files (send files-list-box get-number))
           (files '()))
       (for ((i num-files))
         (set! files (append files (list (send files-list-box get-string i)))))
-      (make-autotest id
+      (make-autotest (generate-autotest-id)
                      (send autotest-name-text-field get-value)
                      activate?
                      files
@@ -787,58 +813,51 @@
   (send minute-text-field set-value (number->string (date-minute (current-date))))
   (send ampm-combo-field set-value ampm))
 
+;; Fills the year, month, date fields with current date values.
+(define (refresh-date-fields)
+  (send year-combo-field set-value (number->string (date-year (current-date))))
+  (send month-combo-field set-value (number->string (date-month (current-date))))
+  (send date-text-field set-value (number->string (date-day (current-date)))))
+
 ;; Fills the configuration pane (right side) for the selected autotest.
-(define (populate-autotest-info lb)
-  (cond ((eq? lb 'default)
+(define (populate-autotest-info at)
+  (cond ((eq? at 'default)
+         (send autotest-name-text-field set-value "")
          (send files-list-box clear)
          (send one-time-periodic-radio-box set-selection 0)
-         (send year-combo-field set-value (number->string (date-year (current-date))))
-         (send month-combo-field set-value (number->string (date-month (current-date))))
-         (send date-text-field set-value (number->string (date-day (current-date))))
-         (send check-daily set-value #f)
-         (send check-monday set-value #f)
-         (send check-tuesday set-value #f)
-         (send check-wednesday set-value #f)
-         (send check-thursday set-value #f)
-         (send check-friday set-value #f)
-         (send check-saturday set-value #f)
-         (send check-sunday set-value #f)
-         (toggle-onetime-periodic)
+         (toggle-onetime-periodic-pane)
+         (uncheck-all-days)         
+         (refresh-date-fields)
          (refresh-time-fields)
          (send check-notify set-value #f)
-         (send mailing-list-name-message set-label NO-MAILING-LIST-MESSAGE))        
+         (send mailing-list-name-message set-label NO-MAILING-LIST-MESSAGE))
         (else
-         (define selection-index (send lb get-selection))
-         (cond ((equal? #f selection-index)
-                (send selected-autotest-message set-label NO-AUTOTEST-SELECTED-MESSAGE))
-               (else
-                (let ((selected-at (send lb get-data selection-index)))
-                  (send autotest-name-text-field set-value (autotest-name selected-at))
-                  (set-autotest-name-text-field-background)
-                  (send files-list-box clear)
-                  (for-each (lambda (file) (send files-list-box append file)) (autotest-files selected-at))
-                  (if (eq? 'one-time (autotest-type selected-at))
-                      (send one-time-periodic-radio-box set-selection 0)
-                      (send one-time-periodic-radio-box set-selection 1))
-                  (send year-combo-field set-value (number->string (autotest-year selected-at)))
-                  (send month-combo-field set-value (number->string (autotest-month selected-at)))
-                  (send date-text-field set-value (number->string (autotest-date selected-at)))
-                  (send check-daily set-value (autotest-daily? selected-at))
-                  (send check-monday set-value (autotest-mon? selected-at))
-                  (send check-tuesday set-value (autotest-tue? selected-at))
-                  (send check-wednesday set-value (autotest-wed? selected-at))
-                  (send check-thursday set-value (autotest-thu? selected-at))
-                  (send check-friday set-value (autotest-fri? selected-at))
-                  (send check-saturday set-value (autotest-sat? selected-at))
-                  (send check-sunday set-value (autotest-sun? selected-at))
-                  (toggle-onetime-periodic)
-                  (send hour-combo-field set-value (number->string (autotest-hour selected-at)))
-                  (send minute-text-field set-value (number->string (autotest-minute selected-at)))
-                  (send ampm-combo-field set-value (autotest-ampm selected-at))
-                  (send check-notify set-value (autotest-notify? selected-at))
-                  (if (not (equal? #f selected-email-db))
-                      (send mailing-list-name-message set-label (email-db-name selected-email-db))
-                      (send mailing-list-name-message set-label NO-MAILING-LIST-MESSAGE))))))))
+         (send autotest-name-text-field set-value (autotest-name at))
+         (set-autotest-name-text-field-background)
+         (send files-list-box clear)
+         (for-each (lambda (file) (send files-list-box append file)) (autotest-files at))
+         (if (eq? 'one-time (autotest-type at))
+             (send one-time-periodic-radio-box set-selection 0)
+             (send one-time-periodic-radio-box set-selection 1))
+         (send year-combo-field set-value (number->string (autotest-year at)))
+         (send month-combo-field set-value (number->string (autotest-month at)))
+         (send date-text-field set-value (number->string (autotest-date at)))
+         (send check-daily set-value (autotest-daily? at))
+         (send check-monday set-value (autotest-mon? at))
+         (send check-tuesday set-value (autotest-tue? at))
+         (send check-wednesday set-value (autotest-wed? at))
+         (send check-thursday set-value (autotest-thu? at))
+         (send check-friday set-value (autotest-fri? at))
+         (send check-saturday set-value (autotest-sat? at))
+         (send check-sunday set-value (autotest-sun? at))
+         (toggle-onetime-periodic-pane)
+         (send hour-combo-field set-value (number->string (autotest-hour at)))
+         (send minute-text-field set-value (number->string (autotest-minute at)))
+         (send ampm-combo-field set-value (autotest-ampm at))
+         (send check-notify set-value (autotest-notify? at))
+         (if (not (equal? #f selected-email-db))
+             (send mailing-list-name-message set-label (email-db-name selected-email-db))
+             (send mailing-list-name-message set-label NO-MAILING-LIST-MESSAGE)))))
 
 ;; UI setting for normal browsing (when an entry is selected in autotest lists)
 (define (config-ui-normal-mode)
@@ -847,29 +866,24 @@
            (send inactive-tests-list-box get-data (send inactive-tests-list-box get-selection)))
           (else
            (send active-tests-list-box get-data (send active-tests-list-box get-selection)))))
-  (send last-run-text show #t)
-  (send next-due-text show #t)
   (send last-run-text set-label (autotest-last-run-string at))
   (send next-due-text set-label (autotest-next-due-string at))
-  (send autotest-name-text-field set-value (autotest-name at))
+  (send last-run-text show #t)
+  (send next-due-text show #t)
   (send schedule-new-button enable #t)
   (enable-all-children left-v-panel)
   (send selected-test-name-box change-children name-field-normal-mode)
   (send files-list-box enable #t)
   (enable-file-buttons)
   (send one-time-periodic-radio-box enable #t)
-  (toggle-onetime-periodic)
+  (toggle-onetime-periodic-pane)
   (enable-all-children time-of-day-pane)
   (enable-email-db-controls)
   (send activate-buttons-pane change-children buttons-normal-mode)
   (enable-all-children activate-buttons-pane)
   (set! selected-email-db (autotest-email-db at))
-  (define selection-in-active (send active-tests-list-box get-selection))
   (toggle-warning-icons #f)
-  (cond ((not (equal? #f selection-in-active))
-         (populate-autotest-info active-tests-list-box))
-        (else
-         (populate-autotest-info inactive-tests-list-box))))
+  (populate-autotest-info at))
 
 ;; UI setting when no autotest is selected
 (define (config-ui-no-selection-mode)
@@ -880,14 +894,14 @@
   (send selected-test-name-box change-children name-field-no-selection-mode)
   (send selected-autotest-message set-label NO-AUTOTEST-SELECTED-MESSAGE)
   (send schedule-new-button enable #t)
-  (send files-list-box enable #t)
+  (send files-list-box enable #f)
   (disable-file-buttons)
   (send one-time-periodic-radio-box enable #f)
-  (send date-text-field set-field-background (make-object color% VALID-BG-COLOR))
-  (disable-all-children date-picker-pane)  
+  (set-one-time-fields-background #f)
+  (set-time-fields-background #f)
+  (disable-all-children date-picker-pane)
   (disable-all-children days-of-week-pane)
-  (send minute-text-field set-field-background (make-object color% VALID-BG-COLOR))
-  (disable-all-children time-of-day-pane)  
+  (disable-all-children time-of-day-pane)
   (disable-email-db-controls)
   (send activate-buttons-pane change-children buttons-empty-mode)
   (disable-all-children activate-buttons-pane)
@@ -900,16 +914,16 @@
   (send next-due-text show #f)
   (disable-all-children left-v-panel)
   (send selected-test-name-box change-children name-field-empty-mode)
-  (send selected-autotest-message set-label "No autotest scheduled")
+  (send selected-autotest-message set-label NO-AUTOTEST-SCHEDULED-MESSAGE)
   (send schedule-new-button enable #t)
   (send files-list-box enable #f)
   (disable-file-buttons)
   (send one-time-periodic-radio-box enable #f)
-  (send date-text-field set-field-background (make-object color% VALID-BG-COLOR))
-  (disable-all-children date-picker-pane)  
+  (set-one-time-fields-background #f)
+  (set-time-fields-background #f)
+  (disable-all-children date-picker-pane)
   (disable-all-children days-of-week-pane)
-  (send minute-text-field set-field-background (make-object color% VALID-BG-COLOR))
-  (disable-all-children time-of-day-pane)  
+  (disable-all-children time-of-day-pane)
   (disable-email-db-controls)
   (send activate-buttons-pane change-children buttons-empty-mode)
   (disable-all-children activate-buttons-pane)
@@ -928,18 +942,15 @@
   (send next-due-text show #f)
   (disable-all-children left-v-panel)
   (populate-autotest-info 'default)
-  (send selected-test-name-box change-children name-field-create-mode)
-  (send autotest-name-text-field set-value "")
   (set-autotest-name-text-field-background)
+  (send selected-test-name-box change-children name-field-create-mode)
   (send schedule-new-button enable #f)
   (send files-list-box enable #t)
   (enable-file-buttons)
   (send one-time-periodic-radio-box enable #t)
-  (set-date-text-field-background)
-  (set-minute-text-field-background)
-  (toggle-onetime-periodic)
+  (set-time-fields-background)
+  (toggle-onetime-periodic-pane)
   (enable-all-children time-of-day-pane)
-  (refresh-time-fields)
   (enable-email-db-controls)
   (send activate-buttons-pane change-children buttons-create-mode)
   (set! selected-email-db #f))
@@ -1019,40 +1030,59 @@
 ;; show different background color for invalid entries
 (define (set-autotest-name-text-field-background)
   (if (valid-autotest-name-string? (send autotest-name-text-field get-value))
-      (send autotest-name-text-field set-field-background (make-object color% VALID-BG-COLOR))
-      (send autotest-name-text-field set-field-background (make-object color% INVALID-BG-COLOR))))
+      (send autotest-name-text-field set-field-background VALID-FIELD-COLOR)
+      (send autotest-name-text-field set-field-background INVALID-FIELD-COLOR)))
 
 (define (set-minute-text-field-background)
   (if (valid-minute-string? (send minute-text-field get-value))
-      (send minute-text-field set-field-background (make-object color% VALID-BG-COLOR))
-      (send minute-text-field set-field-background (make-object color% INVALID-BG-COLOR))))
+      (send minute-text-field set-field-background VALID-FIELD-COLOR)
+      (send minute-text-field set-field-background INVALID-FIELD-COLOR)))
 
 (define (set-hour-combo-field-background)
   (if (valid-hour-string? (send hour-combo-field get-value))
-      (send hour-combo-field set-field-background (make-object color% VALID-BG-COLOR))
-      (send hour-combo-field set-field-background (make-object color% INVALID-BG-COLOR))))
+      (send hour-combo-field set-field-background VALID-FIELD-COLOR)
+      (send hour-combo-field set-field-background INVALID-FIELD-COLOR)))
 
 (define (set-ampm-combo-field-background)
   (if (valid-ampm-string? (send ampm-combo-field get-value))
-      (send ampm-combo-field set-field-background (make-object color% VALID-BG-COLOR))
-      (send ampm-combo-field set-field-background (make-object color% INVALID-BG-COLOR))))
+      (send ampm-combo-field set-field-background VALID-FIELD-COLOR)
+      (send ampm-combo-field set-field-background INVALID-FIELD-COLOR)))
 
 (define (set-year-combo-field-background)
   (if (valid-year-string? (send year-combo-field get-value))
-      (send year-combo-field set-field-background (make-object color% VALID-BG-COLOR))
-      (send year-combo-field set-field-background (make-object color% INVALID-BG-COLOR))))
+      (send year-combo-field set-field-background VALID-FIELD-COLOR)
+      (send year-combo-field set-field-background INVALID-FIELD-COLOR)))
 
 (define (set-month-combo-field-background)
   (if (valid-month-string? (send month-combo-field get-value))
-      (send month-combo-field set-field-background (make-object color% VALID-BG-COLOR))
-      (send month-combo-field set-field-background (make-object color% INVALID-BG-COLOR))))
+      (send month-combo-field set-field-background VALID-FIELD-COLOR)
+      (send month-combo-field set-field-background INVALID-FIELD-COLOR)))
 
 (define (set-date-text-field-background)
   (define month (string->number (send month-combo-field get-value)))
   (define year (string->number (send year-combo-field get-value)))
   (if (valid-date-string? (send date-text-field get-value) month year)
-      (send date-text-field set-field-background (make-object color% (make-object color% VALID-BG-COLOR)))
-      (send date-text-field set-field-background (make-object color% (make-object color% INVALID-BG-COLOR)))))
+      (send date-text-field set-field-background VALID-FIELD-COLOR)
+      (send date-text-field set-field-background INVALID-FIELD-COLOR)))
+
+(define (set-time-fields-background (enable? #t))
+  (if (not enable?)
+      (begin (send hour-combo-field set-field-background VALID-FIELD-COLOR)
+             (send minute-text-field set-field-background VALID-FIELD-COLOR)
+             (send ampm-combo-field set-field-background VALID-FIELD-COLOR))
+      (begin (set-hour-combo-field-background)
+             (set-minute-text-field-background)
+             (set-ampm-combo-field-background))))
+             
+(define (set-one-time-fields-background (enable? #t))
+  (if (not enable?)
+      (begin (send year-combo-field set-field-background VALID-FIELD-COLOR)
+             (send month-combo-field set-field-background VALID-FIELD-COLOR)
+             (send date-text-field set-field-background VALID-FIELD-COLOR))
+      (begin
+        (set-date-text-field-background)
+        (set-month-combo-field-background)
+        (set-year-combo-field-background))))
 
 ;; Shows a warning icon for entries that have no field background to signal invalid input.
 (define (toggle-files-warning-icon (enable? #t))
@@ -1109,4 +1139,4 @@
   (populate-active-tests-list-box)
   (populate-inactive-tests-list-box)
   (setup-ui)
-  (send manage-scheduler-frame show #t))
+  (send main-frame show #t))


### PR DESCRIPTION
Fixed bug that .ast run time was getting erased when "save changes"
button was pressed.
Fixed bug that next due time did not get updated until the clock hit the
next minute for recurring test.
Last run time and next due time are automatically refreshed now.
