### PR TITLE
Starting GUI for all components in one window

### DIFF
--- a/Bottle-Racket/bottle-racket.rkt
+++ b/Bottle-Racket/bottle-racket.rkt
@@ -24,8 +24,14 @@
                          (label "Bottle-Racket")))
 
 ; Load in the bottlenose to racket image
+;(define background
+;  (read-bitmap "images/bottleracket.png"))
+
 (define background
-  (read-bitmap "images/bottleracket.png"))
+  (read-bitmap (cond ((eq? (system-type) 'windows) "images\\bottleracket.png")
+                     ((eq? (system-type) 'unix) "images/bottleracket.png")
+                     ((eq? (system-type) 'macosx) "images/bottleracket.png")
+                     (else (error "Platform not supported")))))
 
 (define image-loaded (new message% [parent dialog]
                           [label background]))

--- a/master-gui.rkt
+++ b/master-gui.rkt
@@ -1,0 +1,154 @@
+#lang racket/gui
+
+(require "Common/user-settings-directory.rkt") ; Filepath utilities
+;; (require "Test-Automation/scheduler_ui.rkt") ; For Scheduler GUI. But this breaks on Windows.
+;; (require "Racket-Doc/src/MainGui.rkt") ; Racket-Doc GUI. Breaks on Windows.
+(require setup/dirs)
+
+#|
+Doing Bottle-Racket and Test-Capture for the time being. The other two parts break on Windows.
+
+For Racket-Doc:
+open-output-file: cannot open output file
+  path: C:\OPL\Racket-QA\Racket-QA\./../output/WebPage.rkt
+  system error: The system cannot find the path specified.; errno=3
+
+For Scheduler:
+open-input-file: cannot open input file
+  path: C:\OPL\Racket-QA\Racket-QA\images/add-file-1.png
+  system error: The system cannot find the path specified.; errno=3
+|#
+
+(define RACKET-PATH-UNFIXED
+   (string-append (path->string (find-console-bin-dir))
+                  (cond ((eq? (system-type) 'windows) "racket.exe")
+                        ((eq? (system-type) 'unix) "/racket")
+                        ((eq? (system-type) 'macosx) "/racket")
+                        (else (error "Platform not supported")))))
+
+(define RACKET-PATH
+   (cond ((eq? (system-type) 'windows) (valid-path-windows RACKET-PATH-UNFIXED))
+         ((eq? (system-type) 'unix) (valid-path-linux RACKET-PATH-UNFIXED))
+         ((eq? (system-type) 'macosx) (valid-path-linux RACKET-PATH-UNFIXED))
+         (else (error "Platform not supported"))))
+
+;; **********************************************************************
+;; * Main GUI window
+;; **********************************************************************
+
+; Display simple message prompting user to enter input
+(define description (string-append "Welcome to Racket-QA."))
+
+; Create a dialog window
+(define main-window (new frame% (label "Racket-QA") (width 500)))
+
+(define user-prompt (new message% [parent main-window]
+                         [auto-resize #t]
+                          [label description]))
+
+;; **********************************************************************
+;; * GUI button for Bottle-Racket
+;; **********************************************************************
+
+(new button% [parent main-window] [label "Bottle-Racket"]
+      [callback (lambda (button event)
+                  
+                  ;; Configure necessary paths to call the Bottle-Racket script
+                  (define master-gui-directory (current-directory))
+                  (define bottle-racket-relative-path "Bottle-Racket/bottle-racket.rkt")
+                  (define bottle-racket-full-path (string-append (cleanse-path-string
+                                  (string-append (get-dirpath-from-filepath (current-directory))
+                                                 "/" bottle-racket-relative-path))))
+                  (define bottle-racket-fixed-path (cond ((eq? (system-type) 'windows) (valid-path-windows bottle-racket-full-path))
+                                          ((eq? (system-type) 'unix) (valid-path-linux bottle-racket-full-path))
+                                          ((eq? (system-type) 'macosx) (valid-path-linux bottle-racket-full-path))
+                                          (else (error "Platform not supported"))))
+                  
+                  ;; Debugging
+                  (display "Clicked Bottle-Racket.\n")
+                  (display bottle-racket-full-path)
+                  (display "\n")
+                  (display bottle-racket-fixed-path)
+                  
+                  ;; Make the system call to Bottle-Racket.
+                  (current-directory (get-dirpath-from-filepath bottle-racket-full-path)) ;; Change to Bottle-Racket directory.
+                  (system (string-append RACKET-PATH " " bottle-racket-fixed-path))
+                  (current-directory master-gui-directory) ;; Go back to the main page directory when finished.
+                  
+                                    ) ; end lambda
+      ] ; end callback
+) ;; end button
+
+
+
+;; **********************************************************************
+;; * GUI button for Test-Capture
+;; **********************************************************************
+
+(new button% [parent main-window] [label "Test-Capture"]
+      [callback (lambda (button event)
+
+                  ;; Configure necessary paths to call the test-capture script
+                  (define master-gui-directory (current-directory))
+                  (define test-capture-relative-path "Bottle-Racket/test-capture.rkt")
+                  (define test-capture-full-path (string-append (cleanse-path-string
+                                  (string-append (get-dirpath-from-filepath (current-directory))
+                                                 "/" test-capture-relative-path))))
+                  (define test-capture-fixed-path (cond ((eq? (system-type) 'windows) (valid-path-windows test-capture-full-path))
+                                          ((eq? (system-type) 'unix) (valid-path-linux test-capture-full-path))
+                                          ((eq? (system-type) 'macosx) (valid-path-linux test-capture-full-path))
+                                          (else (error "Platform not supported"))))
+                  
+                  ;; Debugging
+                  (display "Clicked Test-Capture.\n")
+                  (display test-capture-full-path)
+                  (display "\n")
+                  (display test-capture-fixed-path)
+                  
+                  ;; Make the system call to test-capture.
+                  (current-directory (get-dirpath-from-filepath test-capture-full-path)) ;; Change to Bottle-Racket directory.
+                  (system (string-append RACKET-PATH " " test-capture-fixed-path))
+                  (current-directory master-gui-directory) ;; Go back to the main page directory when finished.
+                  
+                                    ) ; end lambda
+      ] ; end callback
+) ;; end button
+
+
+
+;; **********************************************************************
+;; * GUI button for Scheduler
+;; **********************************************************************
+
+(new button% [parent main-window] [label "Scheduler"]
+      [callback (lambda (button event)
+
+                  (display "Clicked Scheduler.\n")
+                  
+                                    ) ; end lambda
+      ] ; end callback
+) ;; end button
+
+
+
+;; **********************************************************************
+;; * GUI button for Racket-Doc
+;; **********************************************************************
+
+(new button% [parent main-window] [label "Racket-Doc"]
+      [callback (lambda (button event)
+
+                  (display "Clicked Racket-Doc.\n")
+                  
+                                    ) ; end lambda
+      ] ; end callback
+) ;; end button
+
+
+;; **********************************************************************
+;; * Display main window
+;; **********************************************************************
+
+(send main-window show #t)
+
+;


### PR DESCRIPTION
The code for Scheduler, QA Email, and Racket-Doc should be checked over for normalizing paths because I tried impementing buttons for Scheduler and Racket-Doc and got errors. Website page also generated, will email that as well. Here http://opls15projects.github.io/Racket-QA/
