### PR TITLE
Fixed "multiple run" bug

### DIFF
--- a/Racket-Doc/src/PageGenerator.rkt
+++ b/Racket-Doc/src/PageGenerator.rkt
@@ -420,7 +420,7 @@
   (write-string "               #:listen-ip \"127.0.0.1\"\n" output)
   (write-string "               ;#:port 8080\n" output)
   (write-string "               #:servlet-path \"/\")\n" output)
-  (close-output-port output)
+  ;(close-output-port output) ; this breaks mutliple runs
 )
 
 ;;-------------------------------------------------------------------------------------------


### PR DESCRIPTION
Now you can run Racket-Doc, and then re-run it without the "output-port closed error".
