### PR TITLE
Changes in PageGenerator allow for closed port now

### DIFF
--- a/Racket-Doc/src/PageGenerator.rkt
+++ b/Racket-Doc/src/PageGenerator.rkt
@@ -385,6 +385,7 @@
   (write-string ";               #:listen-ip \"127.0.0.1\"\n" output)
   (write-string ";               ;#:port 8080\n" output)
   (write-string ";               #:servlet-path \"/\")\n" output)
+  (close-output-port output)
 )
 
 ;;-------------------------------------------------------------------------------------------


### PR DESCRIPTION
Going to this commit: https://github.com/oplS15projects/Racket-QA/commit/cc50121574f41c92a41387390bfb5d17062eb3bd we see in PageGenerator.rkt:

(set! output (open-output-file myOutputDir
                                  #:mode 'text
                                  #:exists 'replace))

This may have solved the actual problem. When the output port was being closed originally, this code didn't exist previously in the procedure generationMaster. On windows if you don't close an output port, the full text doesn't get written out to file -- resulting in incomplete files missing parentheses etc. and when I made this one-line change I could also run Racket-Doc several times on Windows while having working generated output.
